### PR TITLE
ibus/common.go: Use WAYLAND_DISPLAY for Ibus socket path on Wayland

### DIFF
--- a/ibus/common.go
+++ b/ibus/common.go
@@ -79,20 +79,31 @@ func GetSocketPath() string {
 	if path != "" {
 		return path
 	}
-	display := os.Getenv("DISPLAY")
+	display := os.Getenv("WAYLAND_DISPLAY")
+	isWayland := true
+	if display == "" {
+		isWayland = false
+		display = os.Getenv("DISPLAY")
+	}
 	if display == "" {
 		fmt.Fprintf(os.Stderr, "DISPLAY is empty! We use default DISPLAY (:0.0)")
 		display = ":0.0"
 	}
-	// format is {hostname}:{displaynumber}.{screennumber}
 	hostname := "unix"
-	HDS := strings.SplitN(display, ":", 2)
-	DS := strings.SplitN(HDS[1], ".", 2)
+	displayNumber := ""
+	if isWayland {
+		displayNumber = display
+	} else {
+		// format is {hostname}:{displaynumber}.{screennumber}
+		HDS := strings.SplitN(display, ":", 2)
+		DS := strings.SplitN(HDS[1], ".", 2)
 
-	if HDS[0] != "" {
-		hostname = HDS[0]
+		if HDS[0] != "" {
+			hostname = HDS[0]
+		}
+		displayNumber = DS[0]
 	}
-	p := fmt.Sprintf("%s-%s-%s", GetLocalMachineId(), hostname, DS[0])
+	p := fmt.Sprintf("%s-%s-%s", GetLocalMachineId(), hostname, displayNumber)
 	path = GetUserConfigDir() + "/ibus/bus/" + p
 
 	return path


### PR DESCRIPTION
IBus on Wayland doesn't use the $DISPLAY environment variable, rather uses the $WAYLAND_DISPLAY environment variable to create the socket file.

Not sure if this fixes #10, because I got a different error message than the ones reported in #10, and this PR is related specifically to my error message.

The error message I got was:

```
panic: open /home/smee/.config/ibus/bus/6a3c9f7b36604a2ba7abcf2e41af943e-unix-0: no such file or directory

goroutine 1 [running]:
github.com/varnamproject/govarnam-ibus/ibus.GetAddress()
	github.com/varnamproject/govarnam-ibus/ibus/common.go:66 +0x138
github.com/varnamproject/govarnam-ibus/ibus.NewBus()
	github.com/varnamproject/govarnam-ibus/ibus/bus.go:17 +0x17
main.main()
	github.com/varnamproject/govarnam-ibus/varnam.go:133 +0x53f
```

I got the fix from [https://github.com/BambooEngine/goibus/commit/ea4df577c5d6a814917564d175080c01f10cc09f](https://github.com/BambooEngine/goibus/commit/ea4df577c5d6a814917564d175080c01f10cc09f)